### PR TITLE
feat: add support for multiple geography and geography group filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,11 +67,27 @@ Type: `string`
 
 Default: `null`
 
+### <a name="input_geography_filters"></a> [geography\_filters](#input\_geography\_filters)
+
+Description: If set, the module will only return regions that match any of the specified geographies.
+
+Type: `set(string)`
+
+Default: `null`
+
 ### <a name="input_geography_group_filter"></a> [geography\_group\_filter](#input\_geography\_group\_filter)
 
 Description: If set, the module will only return regions that match the specified geography group.
 
 Type: `string`
+
+Default: `null`
+
+### <a name="input_geography_group_filters"></a> [geography\_group\_filters](#input\_geography\_group\_filters)
+
+Description: If set, the module will only return regions that match any of the specified geography groups.
+
+Type: `set(string)`
 
 Default: `null`
 

--- a/locals.tf
+++ b/locals.tf
@@ -20,8 +20,11 @@ locals {
   locations_all_names = toset([for v in local.locations : v.name])
   # A set of location names that match the geography filter.
   locations_geography_filter = var.geography_filter != null ? toset([for v in local.locations : v.name if v.geography == var.geography_filter]) : local.locations_all_names
+  # Folks can now specify multiple geographies or geography groups to filter by.
+  locations_geography_filters = var.geography_group_filters != null ? toset([for v in local.locations : v.name if contains(var.geography_filters, v.geography)]) : local.locations_all_names
   # A set of location names that match the geography group filter.
-  locations_geography_group_filter = var.geography_group_filter != null ? toset([for v in local.locations : v.name if v.geography_group == var.geography_group_filter]) : local.locations_all_names
+  locations_geography_group_filter  = var.geography_group_filter != null ? toset([for v in local.locations : v.name if v.geography_group == var.geography_group_filter]) : local.locations_all_names
+  locations_geography_group_filters = var.geography_group_filters != null ? toset([for v in local.locations : v.name if contains(var.geography_group_filters, v.geography_group)]) : local.locations_all_names
   # Filter by region names or display names.
   locations_region_filter = var.region_filter != null ? toset([for v in local.locations : v.name if contains(var.region_filter, v.name) || contains(var.region_filter, v.display_name)]) : local.locations_all_names
 }
@@ -55,6 +58,8 @@ locals {
   locations_filtered_names = setintersection(
     local.locations_geography_filter,
     local.locations_geography_group_filter,
+    local.locations_geography_filters,
+    local.locations_geography_group_filters,
     local.locations_final_paired_region_filter,
     local.locations_final_availability_zones_filter,
     local.locations_final_is_recommended_filter,

--- a/variables.tf
+++ b/variables.tf
@@ -17,11 +17,27 @@ If set, the module will only return regions that match the specified geography.
 DESCRIPTION
 }
 
+variable "geography_filters" {
+  type        = set(string)
+  default     = null
+  description = <<DESCRIPTION
+If set, the module will only return regions that match any of the specified geographies.
+DESCRIPTION
+}
+
 variable "geography_group_filter" {
   type        = string
   default     = null
   description = <<DESCRIPTION
 If set, the module will only return regions that match the specified geography group.
+DESCRIPTION
+}
+
+variable "geography_group_filters" {
+  type        = set(string)
+  default     = null
+  description = <<DESCRIPTION
+If set, the module will only return regions that match any of the specified geography groups.
 DESCRIPTION
 }
 


### PR DESCRIPTION
## Description

This PR adds support for filtering by multiple geographies and geography groups through new input variables.

## Changes

- Added `geography_filters` variable (set of strings) to filter by multiple geographies
- Added `geography_group_filters` variable (set of strings) to filter by multiple geography groups
- Updated filtering logic in locals.tf to support the new multi-value filters
- Updated README.md with documentation for the new variables

## Related Issue

Fixes #80

## Breaking Changes

None - This is a backward compatible feature addition. The existing single-value filter variables continue to work as before.